### PR TITLE
Unique identifiers

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -79,7 +79,7 @@ EXCEPTION
     RETURN;
   RAISE;
 END
-$body$
+$body$;
 EOF
 run_migrations "$test_file"
 


### PR DESCRIPTION
A tentative approach to #2. Adds an extra condition and falls back on unique violation. So we get some pretty good output if an identifier is reused e.g:
```sql
SELECT apply_migration('create_foo', $$
CREATE TABLE foo ();
$$);

SELECT apply_migration('create_foo', $$
CREATE TABLE bar ();
$$);
```
Results in:
```
psql:/tmp/tmp.pInuiAKn7l:72: NOTICE:  Applying migration: create_foo (0863bc6fc9e4dd91908df9b9ef51ec83)
 apply_migration
-----------------
 t
(1 row)

psql:/tmp/tmp.pInuiAKn7l:75: NOTICE:  Applying migration: create_foo (d620096c9407eeb2c885888f63ed2b2a)
psql:/tmp/tmp.pInuiAKn7l:75: ERROR:  duplicate key value violates unique constraint "applied_migrations_pkey"
DETAIL:  Key (identifier)=(create_foo) already exists.
```
Renamed `ddl` to `migration_ddl` as postgres threw an ambiguous column error.

The test for this feels a little backwards, feel free to discard this PR in general :smile: 